### PR TITLE
added blur vanish feature for cringe posts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Cringe Guard: filter out cringe content on your LinkedIn feed using AI",
     "author": "Pankaj Tanwar",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "AI-powered Chrome extension that filters cringe, clickbait & low-value posts from your LinkedIn feed in real-time.",
     "content_scripts": [
         {

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -224,6 +224,91 @@
         .error-card svg {
             flex-shrink: 0;
         }
+
+        .filter-mode {
+            margin-top: 16px;
+            padding-top: 16px;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .filter-mode-title {
+            font-weight: bold;
+            margin-bottom: 12px;
+            color: #0077b5;
+        }
+
+        .toggle-container {
+            display: flex;
+            justify-content: center;
+            margin-bottom: 8px;
+        }
+
+        .toggle-slider {
+            position: relative;
+            width: 200px;
+            height: 40px;
+            background: #f1f6f9;
+            border-radius: 20px;
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+        }
+
+        .toggle-option {
+            flex: 1;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1;
+            color: #64748b;
+            font-weight: 600;
+            font-size: 14px;
+            gap: 6px;
+            transition: all 0.3s ease;
+            text-shadow: 0 1px 1px rgba(255, 255, 255, 0.5);
+        }
+
+        .toggle-slider.blur #blur-option {
+            color: white;
+            text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+        }
+
+        .toggle-slider.remove #remove-option {
+            color: white;
+            text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+        }
+
+        .toggle-slider-button {
+            position: absolute;
+            width: 50%;
+            height: 34px;
+            border-radius: 17px;
+            background: #0077b5;
+            left: 3px;
+            top: 3px;
+            transition: all 0.3s cubic-bezier(0.17, 0.67, 0.83, 0.67);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            z-index: 0;
+        }
+
+        .toggle-slider.remove .toggle-slider-button {
+            left: calc(50% - 3px);
+        }
+
+        .mode-description {
+            font-size: 12px;
+            color: #64748b;
+            text-align: center;
+            margin-top: 8px;
+            min-height: 30px;
+        }
+
+        .toggle-option svg {
+            stroke-width: 2.5;
+        }
     </style>
 </head>
 
@@ -269,6 +354,39 @@
                 <div class="stat-item">
                     <span class="stat-value" id="time-saved">0m</span>
                     Time Saved
+                </div>
+            </div>
+
+            <div class="filter-mode">
+                <div class="filter-mode-title">Filter Mode</div>
+                <div class="toggle-container">
+                    <div class="toggle-slider">
+                        <div class="toggle-option" id="blur-option">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2">
+                                <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                                <circle cx="12" cy="12" r="3"></circle>
+                                <path d="M8 9l-5 5"></path>
+                                <path d="M16 9l5 5"></path>
+                                <path d="M9 16l-5 -5"></path>
+                                <path d="M14 16l5 -5"></path>
+                            </svg>
+                            <span>Blur</span>
+                        </div>
+                        <div class="toggle-option" id="remove-option">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2">
+                                <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                                <line x1="9" y1="9" x2="15" y2="15"></line>
+                                <line x1="15" y1="9" x2="9" y2="15"></line>
+                            </svg>
+                            <span>Vanish</span>
+                        </div>
+                        <div class="toggle-slider-button"></div>
+                    </div>
+                </div>
+                <div class="mode-description" id="mode-description">
+                    Blurs cringe until you decide
                 </div>
             </div>
         </div>

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -26,6 +26,47 @@ document.addEventListener("DOMContentLoaded", function () {
         document.getElementById("time-saved").innerText = Math.ceil(data.timeSavedInMinutes || 0) + "m";
     });
 
+    // Load filter mode setting
+    chrome.storage.sync.get("filterMode", function (data) {
+        const filterMode = data.filterMode || "blur"; // Default to blur if not set
+        const toggleSlider = document.querySelector('.toggle-slider');
+
+        if (filterMode === "remove") {
+            toggleSlider.classList.add('remove');
+            toggleSlider.classList.remove('blur');
+            // TODO - description should be changed only from 1 place
+            document.getElementById('mode-description').textContent =
+                "Vanish cringe completely";
+        } else {
+            toggleSlider.classList.add('blur');
+            toggleSlider.classList.remove('remove');
+            document.getElementById('mode-description').textContent =
+                "Blurs cringe until you decide";
+        }
+    });
+
+    // Listen for filter mode changes
+    const toggleSlider = document.querySelector('.toggle-slider');
+    toggleSlider.addEventListener('click', function () {
+        const currentMode = this.classList.contains('blur') ? 'blur' : 'remove';
+        const newMode = currentMode === 'blur' ? 'remove' : 'blur';
+
+        this.classList.remove(currentMode);
+        this.classList.add(newMode);
+
+        // Update description
+        if (newMode === 'remove') {
+            document.getElementById('mode-description').textContent =
+                "Vanish cringe completely";
+        } else {
+            document.getElementById('mode-description').textContent =
+                "Blurs cringe until you decide";
+        }
+
+        chrome.storage.sync.set({ filterMode: newMode });
+        console.log(`Filter mode changed to: ${newMode}`);
+    });
+
     // take user to the settings page
     const settingsButton = document.querySelector('.settings-icon');
     settingsButton.addEventListener('click', () => {


### PR DESCRIPTION
This PR introduces a sleek toggle for controlling how Cringe Guard filters LinkedIn content:

- Added a new visual toggle between "Blur" and "Remove" filtering modes
- "**Blur**" mode: Blurs cringe until you decide
- "**Vanish**" mode: Vanish cringe completely
- Implemented settings persistence via Chrome storage API
- Integrated with existing detection system
- Matches our existing design language and color scheme

This enhancement gives users more control over their LinkedIn browsing experience while maintaining our lightweight, intuitive interface.