### PR TITLE
added feature to remove promoted posts by default

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Cringe Guard: filter out cringe content on your LinkedIn feed using AI",
     "author": "Pankaj Tanwar",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "AI-powered Chrome extension that filters cringe, clickbait & low-value posts from your LinkedIn feed in real-time.",
     "content_scripts": [
         {


### PR DESCRIPTION
**Description:**

This PR adds the capability to the cringe guard script to identify and blur/hide "Promoted" posts that appear in the LinkedIn feed.

**Key Changes:**

1.  **Extracts Sub-Description:** The script now extracts the 'sub-description' field from the post metadata, which often contains indicators like "Promoted". This data is included in the `postData` object used for cringe detection.
2.  **Adds 'Promoted' Rule:** A new rule has been added to the `isCringe` function (or directly in the processing logic) that checks if the extracted `subDescription` includes the term "Promoted".
3.  **Applies Styling:** If a post's sub-description matches the "Promoted" rule, the standard blurring/hiding style configured by the script is applied to the entire post container.

**Benefits:**

*   Allows users to automatically filter out sponsored content for a cleaner feed experience.
*   Leverages existing data extraction and processing framework.